### PR TITLE
Fix syntax error in iOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In your app delegate's implementation, add the following code:
 	
 		[[LocalyticsAmpSession shared] LocalyticsSession:@"<YOUR_APP_KEY>"];
 	    [[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeAlert];	   
-		[LocalyticsAmpSession shared] handleRemoteNotification:launchOptions]];
+		[[LocalyticsAmpSession shared] handleRemoteNotification:launchOptions];
 	   
 	    return YES;
 	}


### PR DESCRIPTION
This also resolves issue #3.